### PR TITLE
Share DRACOLoader instances

### DIFF
--- a/src/useGLTF.tsx
+++ b/src/useGLTF.tsx
@@ -3,9 +3,10 @@ import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
 import { useLoader } from 'react-three-fiber'
 
+const dracoLoader = new DRACOLoader()
+
 function draco(url: string = 'https://www.gstatic.com/draco/v1/decoders/') {
   return (loader: Loader) => {
-    const dracoLoader = new DRACOLoader()
     dracoLoader.setDecoderPath(url)
     ;(loader as GLTFLoader).setDRACOLoader(dracoLoader)
   }


### PR DESCRIPTION
After migrating from a implementation like this:
```js
const dracoLoader = new DRACOLoader();
dracoLoader.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');

const MyObjectLoader = (url) => {
  const model = useLoader(GLTFLoader, url, (loader) => {
    loader.setDRACOLoader(dracoLoader);
  });

  return model; // Simplification, just exposing the idea....
};
```

It started to complain that `WebAssembly worker` couldn't allocate memory...